### PR TITLE
fix: bug fixes and error handling across planet-express services

### DIFF
--- a/planet-express/api/main.go
+++ b/planet-express/api/main.go
@@ -70,7 +70,9 @@ func handleNewDelivery(w http.ResponseWriter, r *http.Request) {
 	defer resp.Body.Close()
 
 	w.WriteHeader(resp.StatusCode)
-	io.Copy(w, resp.Body)
+	if _, err = io.Copy(w, resp.Body); err != nil {
+		log.Printf("[ERROR] Failed to copy response body: %v", err)
+	}
 	requestsProcessed.WithLabelValues(http.MethodPost, strconv.Itoa(resp.StatusCode)).Inc()
 }
 
@@ -98,5 +100,7 @@ func main() {
 	}()
 
 	fmt.Println("PlanetExpressAPI running on :8080")
-	http.ListenAndServe(":8080", apiMux)
+	if err := http.ListenAndServe(":8080", apiMux); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
 }

--- a/planet-express/crew/main.go
+++ b/planet-express/crew/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"sync"
 )
@@ -12,7 +13,7 @@ type CrewMember struct {
 	Name      string     `json:"name"`
 	Role      string     `json:"role"`
 	Available bool       `json:"available"`
-	Lock      sync.Mutex `json:"lock"`
+	Lock      sync.Mutex `json:"-"`
 }
 
 type CrewResponse struct {
@@ -55,6 +56,7 @@ func returnCrew(w http.ResponseWriter, r *http.Request) {
 	var c CrewMember
 	if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
 		http.Error(w, "Failed to unmarshal data into crew member", http.StatusServiceUnavailable)
+		return
 	}
 
 	for i := range crew {
@@ -75,5 +77,7 @@ func returnCrew(w http.ResponseWriter, r *http.Request) {
 func main() {
 	http.HandleFunc("/crew/reserve", reserveCrew)
 	http.HandleFunc("/crew/return", returnCrew)
-	http.ListenAndServe(":8080", nil)
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
 }

--- a/planet-express/delivery/main.go
+++ b/planet-express/delivery/main.go
@@ -138,7 +138,10 @@ func reserveShip() (ShipInfo, int, error) {
 func createPackage(pkg Package) (Package, int, error) {
 	fmt.Printf("[DEBUG] Sending request to %s\n", fmt.Sprintf("%s/packages", packageServiceURL))
 
-	data, _ := json.Marshal(pkg)
+	data, err := json.Marshal(pkg)
+	if err != nil {
+		return Package{}, http.StatusInternalServerError, fmt.Errorf("failed to marshal package: %w", err)
+	}
 	resp, err := http.Post(fmt.Sprintf("%s/packages", packageServiceURL), "application/json", bytes.NewBuffer(data))
 	if err != nil {
 		return Package{}, http.StatusServiceUnavailable, err
@@ -242,34 +245,47 @@ func handleDelivery(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Delete package from map to prevent boundless growth
-		resp, err = http.Get(fmt.Sprintf("%s/packages/delete?id=%s", packageServiceURL, pkgID))
+		deleteReq, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/packages/delete?id=%s", packageServiceURL, pkgID), nil)
 		if err != nil {
-			fmt.Println("[ERROR] Failed to delete package from list:", err)
+			fmt.Println("[ERROR] Failed to create delete request:", err)
 		} else {
-			resp.Body.Close()
-			fmt.Printf("[INFO] Package %s deleted successfully\n", pkgID)
+			resp, err = http.DefaultClient.Do(deleteReq)
+			if err != nil {
+				fmt.Println("[ERROR] Failed to delete package from list:", err)
+			} else {
+				resp.Body.Close()
+				fmt.Printf("[INFO] Package %s deleted successfully\n", pkgID)
+			}
 		}
 
 		// Return crew to base
 		fmt.Printf("[INFO] Returning crew member %s to base", crew.Name)
-		data, _ := json.Marshal(crew)
-		resp, err = http.Post(fmt.Sprintf("%s/crew/return", crewServiceURL), "application/json", bytes.NewBuffer(data))
+		data, err := json.Marshal(crew)
 		if err != nil {
-			fmt.Printf("[ERROR] Failed to return crew member %s to base:%s", crew.Name, err)
+			fmt.Printf("[ERROR] Failed to marshal crew member %s: %v\n", crew.Name, err)
 		} else {
-			resp.Body.Close()
-			fmt.Printf("[INFO] Crew member %s returned to base.", crew.Name)
+			resp, err = http.Post(fmt.Sprintf("%s/crew/return", crewServiceURL), "application/json", bytes.NewBuffer(data))
+			if err != nil {
+				fmt.Printf("[ERROR] Failed to return crew member %s to base:%s", crew.Name, err)
+			} else {
+				resp.Body.Close()
+				fmt.Printf("[INFO] Crew member %s returned to base.", crew.Name)
+			}
 		}
 
 		// Return ship to base
 		fmt.Println("[INFO] Returning ship to base")
-		data, _ = json.Marshal(ship)
-		resp, err = http.Post(fmt.Sprintf("%s/ship/return", shipServiceURL), "application/json", bytes.NewBuffer(data))
+		data, err = json.Marshal(ship)
 		if err != nil {
-			fmt.Println("[ERROR] Failed to return ship:", err)
+			fmt.Printf("[ERROR] Failed to marshal ship %s: %v\n", ship.Name, err)
 		} else {
-			resp.Body.Close()
-			fmt.Println("[INFO] ship returned to base.")
+			resp, err = http.Post(fmt.Sprintf("%s/ship/return", shipServiceURL), "application/json", bytes.NewBuffer(data))
+			if err != nil {
+				fmt.Println("[ERROR] Failed to return ship:", err)
+			} else {
+				resp.Body.Close()
+				fmt.Println("[INFO] ship returned to base.")
+			}
 		}
 	}(pkg.ID, crew, ship)
 
@@ -298,5 +314,7 @@ func main() {
 	}()
 
 	fmt.Println("[INFO] DeliveryService running on :8080")
-	http.ListenAndServe(":8080", deliveryMux)
+	if err := http.ListenAndServe(":8080", deliveryMux); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
 }

--- a/planet-express/package/main.go
+++ b/planet-express/package/main.go
@@ -4,7 +4,8 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"math/rand"
+	"log"
+	"math/rand/v2"
 	"net/http"
 	"sync"
 )
@@ -96,6 +97,7 @@ func deletePackage(w http.ResponseWriter, r *http.Request) {
 	defer mu.Unlock()
 	if _, ok := packages[id]; !ok {
 		http.NotFound(w, r)
+		return
 	}
 
 	delete(packages, id)
@@ -106,7 +108,7 @@ func randomID() string {
 	const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	b := make([]byte, 8)
 	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
+		b[i] = letters[rand.IntN(len(letters))]
 	}
 	return string(b)
 }
@@ -122,5 +124,7 @@ func main() {
 	http.HandleFunc("/packages/get", getPackage)
 	http.HandleFunc("/packages/update", updatePackageStatus)
 	http.HandleFunc("/packages/delete", deletePackage)
-	http.ListenAndServe(":8080", nil)
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
 }

--- a/planet-express/ship/main.go
+++ b/planet-express/ship/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"sync"
 )
@@ -11,7 +12,7 @@ import (
 type Ship struct {
 	Name      string     `json:"name"`
 	Available bool       `json:"available"`
-	Lock      sync.Mutex `json:"lock"`
+	Lock      sync.Mutex `json:"-"`
 }
 
 type ShipInfo struct {
@@ -86,6 +87,7 @@ func returnShip(w http.ResponseWriter, r *http.Request) {
 	var ship ShipInfo
 	if err := json.NewDecoder(r.Body).Decode(&ship); err != nil {
 		http.Error(w, "Failed to unmarshal data into ship member", http.StatusServiceUnavailable)
+		return
 	}
 
 	for i := range fleet {
@@ -107,5 +109,7 @@ func main() {
 	http.HandleFunc("/ship/status", getStatus)
 	http.HandleFunc("/ship/reserve", reserveShip)
 	http.HandleFunc("/ship/return", returnShip)
-	http.ListenAndServe(":8080", nil)
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
 }

--- a/planet-express/traffic/main.go
+++ b/planet-express/traffic/main.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"os"
 	"time"
@@ -56,7 +56,7 @@ var contents = []string{
 }
 
 func randomChoice(list []string) string {
-	return list[rand.Intn(len(list))]
+	return list[rand.IntN(len(list))]
 }
 
 func sendDelivery() {


### PR DESCRIPTION
## Summary

While exploring the planet-express codebase I found a handful of real bugs and some inconsistencies worth cleaning up. All changes pass `go build ./...` and `go vet ./...`.

### Bugs

- **`crew`, `ship`** — `returnCrew` and `returnShip` were missing a `return` after `http.Error` on decode failure. The handlers would continue executing with a zero-value struct, causing them to iterate the crew/fleet arrays and potentially match on an empty name.

- **`package`** — `deletePackage` was missing a `return` after `http.NotFound`, so it would fall through and call `delete(packages, id)` on a key that didn't exist (harmless but wrong).

- **`delivery` → `package`** — The delivery service called `http.Get(…/packages/delete?id=…)` but the `deletePackage` handler requires `DELETE`. Every package deletion was silently returning `405 Method Not Allowed`, which the goroutine ignored, meaning packages were never cleaned up. Fixed by using `http.NewRequest(http.MethodDelete, …)`.

### Cleanup

- **`crew`, `ship`** — `sync.Mutex` fields had `json:"lock"` tags. Mutexes have no exported fields and should never be serialized — changed to `json:"-"`.

- **`delivery`** — `json.Marshal` return values were discarded with `_` in three places inside the async goroutine. Errors are now handled before the marshaled bytes are used.

- **`package`, `traffic`** — Used `math/rand` / `rand.Intn`, while `delivery` already used `math/rand/v2` / `rand.IntN`. Updated both to be consistent.

- **All services** — `http.ListenAndServe` errors were silently ignored. Now all services call `log.Fatalf` on error, consistent with what `delivery` and `api` were already doing for the metrics server.

- **`api`** — `io.Copy` return value was ignored; now logs on error.

## Test plan

- [ ] Deploy updated images and verify deliveries flow end-to-end (reserve crew → reserve ship → create package → deliver → delete package → return crew/ship)
- [ ] Confirm packages are actually removed after delivery (previously broken)
- [ ] Restart a service with no available port to confirm `log.Fatalf` fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)