### PR TITLE
feat: structured logging with log/slog across planet-express services

### DIFF
--- a/planet-express/api/Deployment.yaml
+++ b/planet-express/api/Deployment.yaml
@@ -20,6 +20,8 @@ spec:
           env:
             - name: DELIVERY_SERVICE_URL
               value: "http://planetexpress-delivery"
+            - name: LOG_LEVEL
+              value: "INFO"
           ports:
             - containerPort: 8080
               name: http

--- a/planet-express/api/main.go
+++ b/planet-express/api/main.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"strconv"
@@ -43,7 +43,7 @@ func getEnv(key, def string) string {
 
 // handleNewDelivery forwards delivery requests to the DeliveryService
 func handleNewDelivery(w http.ResponseWriter, r *http.Request) {
-	fmt.Println("[INFO] Got request for new delivery")
+	slog.Info("Got request for new delivery")
 
 	requestsReceived.WithLabelValues(r.Method).Inc()
 
@@ -60,7 +60,7 @@ func handleNewDelivery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fmt.Printf("[INFO] Dispatching request to delivery-service at %s\n", deliveryServiceURL)
+	slog.Info("Dispatching request to delivery-service", "url", deliveryServiceURL)
 	resp, err := http.Post(fmt.Sprintf("%s/deliveries", deliveryServiceURL), "application/json", bytes.NewBuffer(body))
 	if err != nil {
 		http.Error(w, "Error contacting DeliveryService: "+err.Error(), http.StatusServiceUnavailable)
@@ -71,7 +71,7 @@ func handleNewDelivery(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(resp.StatusCode)
 	if _, err = io.Copy(w, resp.Body); err != nil {
-		log.Printf("[ERROR] Failed to copy response body: %v", err)
+		slog.Error("Failed to copy response body", "err", err)
 	}
 	requestsProcessed.WithLabelValues(http.MethodPost, strconv.Itoa(resp.StatusCode)).Inc()
 }
@@ -81,6 +81,13 @@ func healthCheck(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	levelStr := getEnv("LOG_LEVEL", "INFO")
+	var level slog.Level
+	if err := level.UnmarshalText([]byte(levelStr)); err != nil {
+		level = slog.LevelInfo
+	}
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: level})))
+
 	apiMux := http.NewServeMux()
 	apiMux.HandleFunc("/deliveries", handleNewDelivery)
 	apiMux.HandleFunc("/health", healthCheck)
@@ -92,15 +99,17 @@ func main() {
 	metricsMux.Handle("/metrics", promhttp.Handler())
 
 	go func() {
-		fmt.Println("[INFO] Prometheus metrics endpoint running on :2112")
+		slog.Info("Prometheus metrics endpoint running", "addr", ":2112")
 		err := http.ListenAndServe(":2112", metricsMux)
 		if err != nil {
-			log.Fatalln(err)
+			slog.Error("metrics server error", "err", err)
+			os.Exit(1)
 		}
 	}()
 
-	fmt.Println("PlanetExpressAPI running on :8080")
+	slog.Info("PlanetExpressAPI running", "addr", ":8080")
 	if err := http.ListenAndServe(":8080", apiMux); err != nil {
-		log.Fatalf("server error: %v", err)
+		slog.Error("server error", "err", err)
+		os.Exit(1)
 	}
 }

--- a/planet-express/crew/Deployment.yaml
+++ b/planet-express/crew/Deployment.yaml
@@ -17,6 +17,9 @@ spec:
       containers:
         - name: crew-service
           image: wilgrimthepilgrim/crew:latest
+          env:
+            - name: LOG_LEVEL
+              value: "INFO"
           ports:
             - containerPort: 8080
 ---

--- a/planet-express/crew/main.go
+++ b/planet-express/crew/main.go
@@ -3,9 +3,9 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
+	"os"
 	"sync"
 )
 
@@ -27,15 +27,15 @@ var crew = []CrewMember{
 }
 
 func reserveCrew(w http.ResponseWriter, r *http.Request) {
-	fmt.Println("[INFO] Received request to reserve a crew member")
+	slog.Info("Received request to reserve a crew member")
 	found := false
 	for i := range crew {
 		if crew[i].Lock.TryLock() {
 			if crew[i].Available {
 				found = true
-				fmt.Printf("[INFO] Crew member %s is available\n", crew[i].Name)
+				slog.Info("Crew member is available", "name", crew[i].Name)
 				crew[i].Available = false
-				fmt.Printf("[INFO] Crew member %s has been reserved and is no longer available\n", crew[i].Name)
+				slog.Info("Crew member has been reserved", "name", crew[i].Name)
 				json.NewEncoder(w).Encode(CrewResponse{crew[i].Name})
 			}
 			// Need to unlock the mutex before we return
@@ -46,12 +46,12 @@ func reserveCrew(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	fmt.Println("[WARN] No crew is available")
+	slog.Warn("No crew is available")
 	http.Error(w, "No crew available", http.StatusServiceUnavailable)
 }
 
 func returnCrew(w http.ResponseWriter, r *http.Request) {
-	fmt.Println("[INFO] Received request to return a crew member")
+	slog.Info("Received request to return a crew member")
 
 	var c CrewMember
 	if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
@@ -65,7 +65,7 @@ func returnCrew(w http.ResponseWriter, r *http.Request) {
 			crew[i].Available = true
 			crew[i].Lock.Unlock()
 
-			fmt.Printf("[INFO] Crew member %s was returned successfully\n", c.Name)
+			slog.Info("Crew member returned successfully", "name", c.Name)
 			w.WriteHeader(http.StatusOK)
 			return
 		}
@@ -75,9 +75,20 @@ func returnCrew(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	levelStr := os.Getenv("LOG_LEVEL")
+	if levelStr == "" {
+		levelStr = "INFO"
+	}
+	var level slog.Level
+	if err := level.UnmarshalText([]byte(levelStr)); err != nil {
+		level = slog.LevelInfo
+	}
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: level})))
+
 	http.HandleFunc("/crew/reserve", reserveCrew)
 	http.HandleFunc("/crew/return", returnCrew)
 	if err := http.ListenAndServe(":8080", nil); err != nil {
-		log.Fatalf("server error: %v", err)
+		slog.Error("server error", "err", err)
+		os.Exit(1)
 	}
 }

--- a/planet-express/delivery/Deployment.yaml
+++ b/planet-express/delivery/Deployment.yaml
@@ -24,6 +24,8 @@ spec:
               value: "http://ship-service"
             - name: PACKAGE_SERVICE_URL
               value: "http://package-service"
+            - name: LOG_LEVEL
+              value: "INFO"
           ports:
             - containerPort: 8080
               name: http

--- a/planet-express/delivery/main.go
+++ b/planet-express/delivery/main.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -78,77 +78,80 @@ func getEnv(key, def string) string {
 }
 
 func requestAvailableCrew() (CrewMember, int, error) {
-	fmt.Printf("[DEBUG] Sending request to %s\n", fmt.Sprintf("%s/crew/reserve", crewServiceURL))
-	resp, err := http.Get(fmt.Sprintf("%s/crew/reserve", crewServiceURL))
+	url := fmt.Sprintf("%s/crew/reserve", crewServiceURL)
+	slog.Debug("Sending request to crew service", "url", url)
+	resp, err := http.Get(url)
 	if err != nil {
 		return CrewMember{}, http.StatusServiceUnavailable, err
 	}
 	defer resp.Body.Close()
 
-	fmt.Printf("[DEBUG] Got response from crew service\n")
+	slog.Debug("Got response from crew service")
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return CrewMember{}, resp.StatusCode, fmt.Errorf("error reading response body")
 	}
-	fmt.Printf("[DEBUG] Parsed body of response: %s", string(bodyBytes))
+	slog.Debug("Parsed body of response from crew service", "body", string(bodyBytes))
 
 	if resp.StatusCode != http.StatusOK {
 		return CrewMember{}, resp.StatusCode, fmt.Errorf("crew service error: %s", bodyBytes)
 	}
-	fmt.Printf("[DEBUG] Status code is OKAY\n")
+	slog.Debug("Crew service status code OK")
 
 	var crew CrewMember
 	if err := json.Unmarshal(bodyBytes, &crew); err != nil {
 		return CrewMember{}, resp.StatusCode, err
 	}
-	fmt.Printf("[DEBUG] Unmarshaled into %s\n", crew)
+	slog.Debug("Unmarshaled crew member", "name", crew.Name)
 
 	return crew, http.StatusOK, nil
 }
 
 func reserveShip() (ShipInfo, int, error) {
-	fmt.Printf("[DEBUG] Sending request to %s\n", fmt.Sprintf("%s/ship/reserve", shipServiceURL))
-	resp, err := http.Post(fmt.Sprintf("%s/ship/reserve", shipServiceURL), "application/json", nil)
+	url := fmt.Sprintf("%s/ship/reserve", shipServiceURL)
+	slog.Debug("Sending request to ship service", "url", url)
+	resp, err := http.Post(url, "application/json", nil)
 	if err != nil {
 		return ShipInfo{}, http.StatusServiceUnavailable, err
 	}
 	defer resp.Body.Close()
 
-	fmt.Printf("[DEBUG] Got response from ship service\n")
+	slog.Debug("Got response from ship service")
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return ShipInfo{}, resp.StatusCode, fmt.Errorf("error reading response body")
 	}
-	fmt.Printf("[DEBUG] Parsed body of response: %s", string(bodyBytes))
+	slog.Debug("Parsed body of response from ship service", "body", string(bodyBytes))
 
 	if resp.StatusCode != http.StatusOK {
 		return ShipInfo{}, resp.StatusCode, fmt.Errorf("ship reservation failed: %s", string(bodyBytes))
 	}
 
-	fmt.Printf("[DEBUG] Status code is OKAY\n")
+	slog.Debug("Ship service status code OK")
 	var ship ShipInfo
 	if err := json.Unmarshal(bodyBytes, &ship); err != nil {
 		return ShipInfo{}, resp.StatusCode, err
 	}
-	fmt.Printf("[DEBUG] Unmarshaled into %v\n", ship)
+	slog.Debug("Unmarshaled ship info", "name", ship.Name)
 
 	return ship, resp.StatusCode, nil
 }
 
 func createPackage(pkg Package) (Package, int, error) {
-	fmt.Printf("[DEBUG] Sending request to %s\n", fmt.Sprintf("%s/packages", packageServiceURL))
+	url := fmt.Sprintf("%s/packages", packageServiceURL)
+	slog.Debug("Sending request to package service", "url", url)
 
 	data, err := json.Marshal(pkg)
 	if err != nil {
 		return Package{}, http.StatusInternalServerError, fmt.Errorf("failed to marshal package: %w", err)
 	}
-	resp, err := http.Post(fmt.Sprintf("%s/packages", packageServiceURL), "application/json", bytes.NewBuffer(data))
+	resp, err := http.Post(url, "application/json", bytes.NewBuffer(data))
 	if err != nil {
 		return Package{}, http.StatusServiceUnavailable, err
 	}
 	defer resp.Body.Close()
 
-	fmt.Printf("[DEBUG] Got response from package service\n")
+	slog.Debug("Got response from package service")
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return Package{}, resp.StatusCode, fmt.Errorf("error reading response body")
@@ -158,12 +161,12 @@ func createPackage(pkg Package) (Package, int, error) {
 		return Package{}, resp.StatusCode, fmt.Errorf("package creation failed: %s", string(bodyBytes))
 	}
 
-	fmt.Printf("[DEBUG] Status code is OKAY\n")
+	slog.Debug("Package service status code OK")
 	var created Package
 	if err := json.Unmarshal(bodyBytes, &created); err != nil {
 		return Package{}, resp.StatusCode, err
 	}
-	fmt.Printf("[DEBUG] Unmarshaled into %s\n", created)
+	slog.Debug("Unmarshaled package", "id", created.ID)
 
 	return created, resp.StatusCode, nil
 }
@@ -177,7 +180,7 @@ func handleDelivery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fmt.Println("[DEBUG] Got request for new delivery")
+	slog.Debug("Got request for new delivery")
 	var req DeliveryRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -185,16 +188,16 @@ func handleDelivery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fmt.Println("[INFO] Dispatching request for available crew")
+	slog.Info("Dispatching request for available crew")
 	crew, statusCode, err := requestAvailableCrew()
 	if err != nil {
 		http.Error(w, err.Error(), statusCode)
 		requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(statusCode)).Inc()
 		return
 	}
-	fmt.Printf("[DEBUG] Got crew member %s\n", crew.Name)
+	slog.Debug("Got crew member", "name", crew.Name)
 
-	fmt.Println("[INFO] Dispatching request to reserve ship")
+	slog.Info("Dispatching request to reserve ship")
 	ship, statusCode, err := reserveShip()
 	if err != nil {
 		http.Error(w, err.Error(), statusCode)
@@ -202,14 +205,14 @@ func handleDelivery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fmt.Println("[INFO] Got both crew member and ship")
+	slog.Info("Got both crew member and ship")
 	if (crew == CrewMember{}) || (ship == ShipInfo{}) {
 		http.Error(w, "Unable to get ship or crew", http.StatusServiceUnavailable)
 		requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusServiceUnavailable)).Inc()
 		return
 	}
 
-	fmt.Println("[INFO] Dispatching request to create new package")
+	slog.Info("Dispatching request to create new package")
 	pkg, statusCode, err := createPackage(Package{
 		Recipient: req.Recipient,
 		Address:   req.Address,
@@ -227,64 +230,64 @@ func handleDelivery(w http.ResponseWriter, r *http.Request) {
 		Ship:    ship,
 		Package: pkg,
 	}
-	fmt.Printf("[INFO] Delivery ticket created: %v\n", ticket)
+	slog.Info("Delivery ticket created", "crew", ticket.Crew.Name, "ship", ticket.Ship.Name, "package_id", ticket.Package.ID)
 
 	// Simulate random delivery time
 	go func(pkgID string, crew CrewMember, ship ShipInfo) {
 		delay := time.Duration(rand.IntN(5)+1) * time.Second
-		fmt.Printf("[INFO] ship in-flight for %v delivering package %s\n", delay, pkgID)
+		slog.Info("Ship in-flight", "delay", delay, "package_id", pkgID)
 		time.Sleep(delay)
 
 		// Mark package as delivered
 		resp, err := http.Get(fmt.Sprintf("%s/packages/update?id=%s&status=delivered", packageServiceURL, pkgID))
 		if err != nil {
-			fmt.Println("[ERROR] Failed to update package status:", err)
+			slog.Error("Failed to update package status", "err", err)
 		} else {
 			resp.Body.Close()
-			fmt.Printf("[INFO] Package %s marked as delivered\n", pkgID)
+			slog.Info("Package marked as delivered", "package_id", pkgID)
 		}
 
 		// Delete package from map to prevent boundless growth
 		deleteReq, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/packages/delete?id=%s", packageServiceURL, pkgID), nil)
 		if err != nil {
-			fmt.Println("[ERROR] Failed to create delete request:", err)
+			slog.Error("Failed to create delete request", "err", err)
 		} else {
 			resp, err = http.DefaultClient.Do(deleteReq)
 			if err != nil {
-				fmt.Println("[ERROR] Failed to delete package from list:", err)
+				slog.Error("Failed to delete package from list", "err", err)
 			} else {
 				resp.Body.Close()
-				fmt.Printf("[INFO] Package %s deleted successfully\n", pkgID)
+				slog.Info("Package deleted successfully", "package_id", pkgID)
 			}
 		}
 
 		// Return crew to base
-		fmt.Printf("[INFO] Returning crew member %s to base", crew.Name)
+		slog.Info("Returning crew member to base", "name", crew.Name)
 		data, err := json.Marshal(crew)
 		if err != nil {
-			fmt.Printf("[ERROR] Failed to marshal crew member %s: %v\n", crew.Name, err)
+			slog.Error("Failed to marshal crew member", "name", crew.Name, "err", err)
 		} else {
 			resp, err = http.Post(fmt.Sprintf("%s/crew/return", crewServiceURL), "application/json", bytes.NewBuffer(data))
 			if err != nil {
-				fmt.Printf("[ERROR] Failed to return crew member %s to base:%s", crew.Name, err)
+				slog.Error("Failed to return crew member to base", "name", crew.Name, "err", err)
 			} else {
 				resp.Body.Close()
-				fmt.Printf("[INFO] Crew member %s returned to base.", crew.Name)
+				slog.Info("Crew member returned to base", "name", crew.Name)
 			}
 		}
 
 		// Return ship to base
-		fmt.Println("[INFO] Returning ship to base")
+		slog.Info("Returning ship to base")
 		data, err = json.Marshal(ship)
 		if err != nil {
-			fmt.Printf("[ERROR] Failed to marshal ship %s: %v\n", ship.Name, err)
+			slog.Error("Failed to marshal ship", "name", ship.Name, "err", err)
 		} else {
 			resp, err = http.Post(fmt.Sprintf("%s/ship/return", shipServiceURL), "application/json", bytes.NewBuffer(data))
 			if err != nil {
-				fmt.Println("[ERROR] Failed to return ship:", err)
+				slog.Error("Failed to return ship", "err", err)
 			} else {
 				resp.Body.Close()
-				fmt.Println("[INFO] ship returned to base.")
+				slog.Info("Ship returned to base")
 			}
 		}
 	}(pkg.ID, crew, ship)
@@ -296,6 +299,13 @@ func handleDelivery(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	levelStr := getEnv("LOG_LEVEL", "INFO")
+	var level slog.Level
+	if err := level.UnmarshalText([]byte(levelStr)); err != nil {
+		level = slog.LevelInfo
+	}
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: level})))
+
 	deliveryMux := http.NewServeMux()
 	deliveryMux.HandleFunc("/deliveries", handleDelivery)
 
@@ -306,15 +316,17 @@ func main() {
 	metricsMux.Handle("/metrics", promhttp.Handler())
 
 	go func() {
-		fmt.Println("[INFO] Prometheus metrics endpoint running on :2112")
+		slog.Info("Prometheus metrics endpoint running", "addr", ":2112")
 		err := http.ListenAndServe(":2112", metricsMux)
 		if err != nil {
-			log.Fatalln(err)
+			slog.Error("metrics server error", "err", err)
+			os.Exit(1)
 		}
 	}()
 
-	fmt.Println("[INFO] DeliveryService running on :8080")
+	slog.Info("DeliveryService running", "addr", ":8080")
 	if err := http.ListenAndServe(":8080", deliveryMux); err != nil {
-		log.Fatalf("server error: %v", err)
+		slog.Error("server error", "err", err)
+		os.Exit(1)
 	}
 }

--- a/planet-express/package/Deployment.yaml
+++ b/planet-express/package/Deployment.yaml
@@ -17,6 +17,9 @@ spec:
       containers:
         - name: package-service
           image: wilgrimthepilgrim/package:latest
+          env:
+            - name: LOG_LEVEL
+              value: "INFO"
           ports:
             - containerPort: 8080
 ---

--- a/planet-express/package/main.go
+++ b/planet-express/package/main.go
@@ -3,10 +3,10 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
-	"log"
+	"log/slog"
 	"math/rand/v2"
 	"net/http"
+	"os"
 	"sync"
 )
 
@@ -49,7 +49,7 @@ func listPackages(w http.ResponseWriter, _ *http.Request) {
 }
 
 func getPackage(w http.ResponseWriter, r *http.Request) {
-	fmt.Println("[INFO] Received request to get a package")
+	slog.Info("Received request to get a package")
 	id := r.URL.Query().Get("id")
 	mu.Lock()
 	defer mu.Unlock()
@@ -61,7 +61,7 @@ func getPackage(w http.ResponseWriter, r *http.Request) {
 }
 
 func updatePackageStatus(w http.ResponseWriter, r *http.Request) {
-	fmt.Println("[INFO] Received request to update package status")
+	slog.Info("Received request to update package status")
 	id := r.URL.Query().Get("id")
 	status := r.URL.Query().Get("status")
 	if status == "" {
@@ -74,15 +74,15 @@ func updatePackageStatus(w http.ResponseWriter, r *http.Request) {
 		pkg.Status = status
 		packages[id] = pkg
 		json.NewEncoder(w).Encode(pkg)
-		fmt.Printf("[INFO] Successfully updated status of package %s\n", pkg.ID)
+		slog.Info("Successfully updated package status", "id", pkg.ID, "status", status)
 	} else {
 		http.NotFound(w, r)
-		fmt.Println("[WARN] Package was not found!")
+		slog.Warn("Package was not found", "id", id)
 	}
 }
 
 func deletePackage(w http.ResponseWriter, r *http.Request) {
-	fmt.Println("[INFO] Received request to delete package")
+	slog.Info("Received request to delete package")
 	if r.Method != http.MethodDelete {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -114,6 +114,16 @@ func randomID() string {
 }
 
 func main() {
+	levelStr := os.Getenv("LOG_LEVEL")
+	if levelStr == "" {
+		levelStr = "INFO"
+	}
+	var level slog.Level
+	if err := level.UnmarshalText([]byte(levelStr)); err != nil {
+		level = slog.LevelInfo
+	}
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: level})))
+
 	http.HandleFunc("/packages", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {
 			createPackage(w, r)
@@ -125,6 +135,7 @@ func main() {
 	http.HandleFunc("/packages/update", updatePackageStatus)
 	http.HandleFunc("/packages/delete", deletePackage)
 	if err := http.ListenAndServe(":8080", nil); err != nil {
-		log.Fatalf("server error: %v", err)
+		slog.Error("server error", "err", err)
+		os.Exit(1)
 	}
 }

--- a/planet-express/ship/Deployment.yaml
+++ b/planet-express/ship/Deployment.yaml
@@ -17,6 +17,9 @@ spec:
       containers:
         - name: ship-service
           image: wilgrimthepilgrim/ship:latest
+          env:
+            - name: LOG_LEVEL
+              value: "INFO"
           ports:
             - containerPort: 8080
           imagePullPolicy: Always

--- a/planet-express/ship/main.go
+++ b/planet-express/ship/main.go
@@ -3,9 +3,9 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
+	"os"
 	"sync"
 )
 
@@ -27,7 +27,7 @@ var fleet = []Ship{
 }
 
 func getStatus(w http.ResponseWriter, r *http.Request) {
-	fmt.Println("[INFO] Received request for ship status")
+	slog.Info("Received request for ship status")
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -57,16 +57,16 @@ func getStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 func reserveShip(w http.ResponseWriter, r *http.Request) {
-	fmt.Println("[INFO] Received request to reserve ship")
+	slog.Info("Received request to reserve ship")
 
 	found := false
 	for i := range fleet {
 		if fleet[i].Lock.TryLock() {
 			if fleet[i].Available {
 				found = true
-				fmt.Printf("[INFO] Ship %s is available\n", fleet[i].Name)
+				slog.Info("Ship is available", "name", fleet[i].Name)
 				fleet[i].Available = false
-				fmt.Printf("[INFO] Ship %s has been reserved and is no longer available\n", fleet[i].Name)
+				slog.Info("Ship has been reserved", "name", fleet[i].Name)
 				json.NewEncoder(w).Encode(ShipInfo{fleet[i].Name, fleet[i].Available})
 			}
 
@@ -77,12 +77,12 @@ func reserveShip(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	fmt.Println("[WARN] No ship is available")
+	slog.Warn("No ship is available")
 	http.Error(w, "No ship available", http.StatusServiceUnavailable)
 }
 
 func returnShip(w http.ResponseWriter, r *http.Request) {
-	fmt.Println("[INFO] Received request to return ship")
+	slog.Info("Received request to return ship")
 
 	var ship ShipInfo
 	if err := json.NewDecoder(r.Body).Decode(&ship); err != nil {
@@ -92,11 +92,11 @@ func returnShip(w http.ResponseWriter, r *http.Request) {
 
 	for i := range fleet {
 		if fleet[i].Name == ship.Name {
-			fmt.Printf("[INFO] Returning ship %s to base\n", fleet[i].Name)
+			slog.Info("Returning ship to base", "name", fleet[i].Name)
 			fleet[i].Lock.Lock()
 			fleet[i].Available = true
 			fleet[i].Lock.Unlock()
-			fmt.Printf("[INFO] Ship %s has been returned and is now available\n", fleet[i].Name)
+			slog.Info("Ship returned and is now available", "name", fleet[i].Name)
 			w.WriteHeader(http.StatusOK)
 			return
 		}
@@ -106,10 +106,21 @@ func returnShip(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	levelStr := os.Getenv("LOG_LEVEL")
+	if levelStr == "" {
+		levelStr = "INFO"
+	}
+	var level slog.Level
+	if err := level.UnmarshalText([]byte(levelStr)); err != nil {
+		level = slog.LevelInfo
+	}
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: level})))
+
 	http.HandleFunc("/ship/status", getStatus)
 	http.HandleFunc("/ship/reserve", reserveShip)
 	http.HandleFunc("/ship/return", returnShip)
 	if err := http.ListenAndServe(":8080", nil); err != nil {
-		log.Fatalf("server error: %v", err)
+		slog.Error("server error", "err", err)
+		os.Exit(1)
 	}
 }

--- a/planet-express/traffic/Deployment.yaml
+++ b/planet-express/traffic/Deployment.yaml
@@ -25,6 +25,8 @@ spec:
               value: "http://planetexpress-api/deliveries"
             - name: INTERVAL_SECONDS
               value: "1"
+            - name: LOG_LEVEL
+              value: "INFO"
 ---
 apiVersion: v1
 kind: Service

--- a/planet-express/traffic/main.go
+++ b/planet-express/traffic/main.go
@@ -4,8 +4,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
-	"log"
+	"log/slog"
 	"math/rand/v2"
 	"net/http"
 	"os"
@@ -71,15 +70,22 @@ func sendDelivery() {
 
 	resp, err := http.Post(apiURL, "application/json", bytes.NewBuffer(data))
 	if err != nil {
-		fmt.Printf("[ERROR] Failed to send delivery: %v\n", err)
+		slog.Error("Failed to send delivery", "err", err)
 		return
 	}
 	defer resp.Body.Close()
 
-	fmt.Printf("[INFO] Sent delivery: %+v | Status: %d\n", req, resp.StatusCode)
+	slog.Info("Sent delivery", "recipient", req.Recipient, "address", req.Address, "contents", req.Contents, "status", resp.StatusCode)
 }
 
 func main() {
+	levelStr := getEnv("LOG_LEVEL", "INFO")
+	var level slog.Level
+	if err := level.UnmarshalText([]byte(levelStr)); err != nil {
+		level = slog.LevelInfo
+	}
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: level})))
+
 	interval := 1 * time.Second
 	if val, ok := os.LookupEnv("INTERVAL_SECONDS"); ok {
 		if val, err := time.ParseDuration(val + "s"); err == nil {
@@ -91,14 +97,15 @@ func main() {
 	http.Handle("/metrics", promhttp.Handler())
 
 	go func() {
-		fmt.Println("[INFO] Prometheus metrics endpoint running on :2112")
+		slog.Info("Prometheus metrics endpoint running", "addr", ":2112")
 		err := http.ListenAndServe(":2112", nil)
 		if err != nil {
-			log.Fatalln(err)
+			slog.Error("metrics server error", "err", err)
+			os.Exit(1)
 		}
 	}()
 
-	fmt.Printf("[INFO] Delivery Traffic Generator running, sending requests to %s every %v\n", apiURL, interval)
+	slog.Info("Delivery Traffic Generator running", "url", apiURL, "interval", interval)
 	for {
 		sendDelivery()
 		time.Sleep(interval)


### PR DESCRIPTION
## Summary

- Replace all `fmt.Print*` and `log.Print*` calls in all six microservices (api, crew, ship, package, delivery, traffic) with `log/slog` using a JSON handler
- Log level is now configurable at runtime via a `LOG_LEVEL` environment variable (default: `INFO`) — no rebuild required to change it
- All six `Deployment.yaml` manifests updated to expose `LOG_LEVEL` so it can be adjusted at the Kubernetes level
- No new external dependencies — `log/slog` is part of the Go standard library (Go 1.21+)
- Unstructured format strings (e.g. `[INFO] Crew member %s reserved`) are replaced with structured key-value pairs (e.g. `slog.Info("Crew member reserved", "name", crew.Name)`)
- The many verbose `[DEBUG]` statements in the delivery service are now silent at the default INFO level; set `LOG_LEVEL=DEBUG` to enable them

## Test plan

- [ ] `go build ./...` from `planet-express/` compiles cleanly
- [ ] `grep -rn "fmt\.Print\|log\.Print\|log\.Fatal" planet-express/` returns no results
- [ ] Run a service locally and confirm JSON log output: `go run ./delivery/main.go`
- [ ] Confirm `LOG_LEVEL=DEBUG go run ./delivery/main.go` surfaces debug messages
- [ ] `kubectl apply --dry-run=client -f planet-express/delivery/Deployment.yaml` validates cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)