### PR TITLE
feat: add Prometheus metrics to crew, ship, and package services

### DIFF
--- a/planet-express/crew/Deployment.yaml
+++ b/planet-express/crew/Deployment.yaml
@@ -22,15 +22,33 @@ spec:
               value: "INFO"
           ports:
             - containerPort: 8080
+            - containerPort: 2112
+              name: metrics
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: crew-service
   namespace: planet-express
+  labels:
+    app: crew-service
 spec:
   selector:
     app: crew-service
   ports:
     - port: 80
       targetPort: 8080
+    - port: 2112
+      name: metrics
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: crew-service
+  namespace: planet-express
+spec:
+  selector:
+    matchLabels:
+      app: crew-service
+  endpoints:
+    - port: metrics

--- a/planet-express/crew/main.go
+++ b/planet-express/crew/main.go
@@ -6,7 +6,11 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strconv"
 	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 type CrewMember struct {
@@ -20,13 +24,32 @@ type CrewResponse struct {
 	Name string `json:"name"`
 }
 
-var crew = []CrewMember{
-	{"Fry", "Delivery Boy", true, sync.Mutex{}},
-	{"Leela", "Captain", true, sync.Mutex{}},
-	{"Bender", "Bending Unit", true, sync.Mutex{}},
-}
+var (
+	crew = []CrewMember{
+		{"Fry", "Delivery Boy", true, sync.Mutex{}},
+		{"Leela", "Captain", true, sync.Mutex{}},
+		{"Bender", "Bending Unit", true, sync.Mutex{}},
+	}
+
+	requestsReceived = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "planet_express_crew_requests_received_total",
+			Help: "The total number of requests received by the crew service",
+		},
+		[]string{"method"},
+	)
+
+	requestsProcessed = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "planet_express_crew_requests_processed_total",
+			Help: "The total number of requests handled (processed) by the crew service",
+		},
+		[]string{"method", "code"},
+	)
+)
 
 func reserveCrew(w http.ResponseWriter, r *http.Request) {
+	requestsReceived.WithLabelValues(r.Method).Inc()
 	slog.Info("Received request to reserve a crew member")
 	found := false
 	for i := range crew {
@@ -41,20 +64,24 @@ func reserveCrew(w http.ResponseWriter, r *http.Request) {
 			// Need to unlock the mutex before we return
 			crew[i].Lock.Unlock()
 			if found {
+				requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusOK)).Inc()
 				return
 			}
 		}
 	}
 
 	slog.Warn("No crew is available")
+	requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusServiceUnavailable)).Inc()
 	http.Error(w, "No crew available", http.StatusServiceUnavailable)
 }
 
 func returnCrew(w http.ResponseWriter, r *http.Request) {
+	requestsReceived.WithLabelValues(r.Method).Inc()
 	slog.Info("Received request to return a crew member")
 
 	var c CrewMember
 	if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
+		requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusServiceUnavailable)).Inc()
 		http.Error(w, "Failed to unmarshal data into crew member", http.StatusServiceUnavailable)
 		return
 	}
@@ -66,11 +93,13 @@ func returnCrew(w http.ResponseWriter, r *http.Request) {
 			crew[i].Lock.Unlock()
 
 			slog.Info("Crew member returned successfully", "name", c.Name)
+			requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusOK)).Inc()
 			w.WriteHeader(http.StatusOK)
 			return
 		}
 	}
 
+	requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusNotFound)).Inc()
 	http.Error(w, "Crew member not found", http.StatusNotFound)
 }
 
@@ -85,9 +114,26 @@ func main() {
 	}
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: level})))
 
-	http.HandleFunc("/crew/reserve", reserveCrew)
-	http.HandleFunc("/crew/return", returnCrew)
-	if err := http.ListenAndServe(":8080", nil); err != nil {
+	prometheus.MustRegister(requestsReceived)
+	prometheus.MustRegister(requestsProcessed)
+
+	crewMux := http.NewServeMux()
+	crewMux.HandleFunc("/crew/reserve", reserveCrew)
+	crewMux.HandleFunc("/crew/return", returnCrew)
+
+	metricsMux := http.NewServeMux()
+	metricsMux.Handle("/metrics", promhttp.Handler())
+
+	go func() {
+		slog.Info("Prometheus metrics endpoint running", "addr", ":2112")
+		if err := http.ListenAndServe(":2112", metricsMux); err != nil {
+			slog.Error("metrics server error", "err", err)
+			os.Exit(1)
+		}
+	}()
+
+	slog.Info("CrewService running", "addr", ":8080")
+	if err := http.ListenAndServe(":8080", crewMux); err != nil {
 		slog.Error("server error", "err", err)
 		os.Exit(1)
 	}

--- a/planet-express/package/Deployment.yaml
+++ b/planet-express/package/Deployment.yaml
@@ -22,15 +22,33 @@ spec:
               value: "INFO"
           ports:
             - containerPort: 8080
+            - containerPort: 2112
+              name: metrics
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: package-service
   namespace: planet-express
+  labels:
+    app: package-service
 spec:
   selector:
     app: package-service
   ports:
     - port: 80
       targetPort: 8080
+    - port: 2112
+      name: metrics
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: package-service
+  namespace: planet-express
+spec:
+  selector:
+    matchLabels:
+      app: package-service
+  endpoints:
+    - port: metrics

--- a/planet-express/package/main.go
+++ b/planet-express/package/main.go
@@ -7,7 +7,11 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"os"
+	"strconv"
 	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 type Package struct {
@@ -21,11 +25,29 @@ type Package struct {
 var (
 	packages = make(map[string]Package)
 	mu       sync.Mutex
+
+	requestsReceived = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "planet_express_package_requests_received_total",
+			Help: "The total number of requests received by the package service",
+		},
+		[]string{"method"},
+	)
+
+	requestsProcessed = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "planet_express_package_requests_processed_total",
+			Help: "The total number of requests handled (processed) by the package service",
+		},
+		[]string{"method", "code"},
+	)
 )
 
 func createPackage(w http.ResponseWriter, r *http.Request) {
+	requestsReceived.WithLabelValues(r.Method).Inc()
 	var pkg Package
 	if err := json.NewDecoder(r.Body).Decode(&pkg); err != nil {
+		requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusBadRequest)).Inc()
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -34,37 +56,45 @@ func createPackage(w http.ResponseWriter, r *http.Request) {
 	pkg.ID = randomID()
 	pkg.Status = "pending"
 	packages[pkg.ID] = pkg
+	requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusCreated)).Inc()
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(pkg)
 }
 
-func listPackages(w http.ResponseWriter, _ *http.Request) {
+func listPackages(w http.ResponseWriter, r *http.Request) {
+	requestsReceived.WithLabelValues(r.Method).Inc()
 	mu.Lock()
 	defer mu.Unlock()
 	list := make([]Package, 0, len(packages))
 	for _, pkg := range packages {
 		list = append(list, pkg)
 	}
+	requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusOK)).Inc()
 	json.NewEncoder(w).Encode(list)
 }
 
 func getPackage(w http.ResponseWriter, r *http.Request) {
+	requestsReceived.WithLabelValues(r.Method).Inc()
 	slog.Info("Received request to get a package")
 	id := r.URL.Query().Get("id")
 	mu.Lock()
 	defer mu.Unlock()
 	if pkg, ok := packages[id]; ok {
+		requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusOK)).Inc()
 		json.NewEncoder(w).Encode(pkg)
 	} else {
+		requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusNotFound)).Inc()
 		http.NotFound(w, r)
 	}
 }
 
 func updatePackageStatus(w http.ResponseWriter, r *http.Request) {
+	requestsReceived.WithLabelValues(r.Method).Inc()
 	slog.Info("Received request to update package status")
 	id := r.URL.Query().Get("id")
 	status := r.URL.Query().Get("status")
 	if status == "" {
+		requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusBadRequest)).Inc()
 		http.Error(w, "Missing status", http.StatusBadRequest)
 		return
 	}
@@ -73,22 +103,27 @@ func updatePackageStatus(w http.ResponseWriter, r *http.Request) {
 	if pkg, ok := packages[id]; ok {
 		pkg.Status = status
 		packages[id] = pkg
+		requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusOK)).Inc()
 		json.NewEncoder(w).Encode(pkg)
 		slog.Info("Successfully updated package status", "id", pkg.ID, "status", status)
 	} else {
+		requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusNotFound)).Inc()
 		http.NotFound(w, r)
 		slog.Warn("Package was not found", "id", id)
 	}
 }
 
 func deletePackage(w http.ResponseWriter, r *http.Request) {
+	requestsReceived.WithLabelValues(r.Method).Inc()
 	slog.Info("Received request to delete package")
 	if r.Method != http.MethodDelete {
+		requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusMethodNotAllowed)).Inc()
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 	id := r.URL.Query().Get("id")
 	if id == "" {
+		requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusBadRequest)).Inc()
 		http.Error(w, "Missing package id in delete request", http.StatusBadRequest)
 		return
 	}
@@ -96,11 +131,13 @@ func deletePackage(w http.ResponseWriter, r *http.Request) {
 	mu.Lock()
 	defer mu.Unlock()
 	if _, ok := packages[id]; !ok {
+		requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusNotFound)).Inc()
 		http.NotFound(w, r)
 		return
 	}
 
 	delete(packages, id)
+	requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusOK)).Inc()
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -124,17 +161,34 @@ func main() {
 	}
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: level})))
 
-	http.HandleFunc("/packages", func(w http.ResponseWriter, r *http.Request) {
+	prometheus.MustRegister(requestsReceived)
+	prometheus.MustRegister(requestsProcessed)
+
+	packageMux := http.NewServeMux()
+	packageMux.HandleFunc("/packages", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {
 			createPackage(w, r)
 		} else {
 			listPackages(w, r)
 		}
 	})
-	http.HandleFunc("/packages/get", getPackage)
-	http.HandleFunc("/packages/update", updatePackageStatus)
-	http.HandleFunc("/packages/delete", deletePackage)
-	if err := http.ListenAndServe(":8080", nil); err != nil {
+	packageMux.HandleFunc("/packages/get", getPackage)
+	packageMux.HandleFunc("/packages/update", updatePackageStatus)
+	packageMux.HandleFunc("/packages/delete", deletePackage)
+
+	metricsMux := http.NewServeMux()
+	metricsMux.Handle("/metrics", promhttp.Handler())
+
+	go func() {
+		slog.Info("Prometheus metrics endpoint running", "addr", ":2112")
+		if err := http.ListenAndServe(":2112", metricsMux); err != nil {
+			slog.Error("metrics server error", "err", err)
+			os.Exit(1)
+		}
+	}()
+
+	slog.Info("PackageService running", "addr", ":8080")
+	if err := http.ListenAndServe(":8080", packageMux); err != nil {
 		slog.Error("server error", "err", err)
 		os.Exit(1)
 	}

--- a/planet-express/ship/Deployment.yaml
+++ b/planet-express/ship/Deployment.yaml
@@ -22,6 +22,8 @@ spec:
               value: "INFO"
           ports:
             - containerPort: 8080
+            - containerPort: 2112
+              name: metrics
           imagePullPolicy: Always
 ---
 apiVersion: v1
@@ -29,9 +31,25 @@ kind: Service
 metadata:
   name: ship-service
   namespace: planet-express
+  labels:
+    app: ship-service
 spec:
   selector:
     app: ship-service
   ports:
     - port: 80
       targetPort: 8080
+    - port: 2112
+      name: metrics
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: ship-service
+  namespace: planet-express
+spec:
+  selector:
+    matchLabels:
+      app: ship-service
+  endpoints:
+    - port: metrics

--- a/planet-express/ship/main.go
+++ b/planet-express/ship/main.go
@@ -6,7 +6,11 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strconv"
 	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 type Ship struct {
@@ -20,20 +24,41 @@ type ShipInfo struct {
 	Available bool   `json:"available"`
 }
 
-var fleet = []Ship{
-	{"Old Bessie", true, sync.Mutex{}},
-	{"The Dinghy", true, sync.Mutex{}},
-	{"Leela's Cruiser", true, sync.Mutex{}},
-}
+var (
+	fleet = []Ship{
+		{"Old Bessie", true, sync.Mutex{}},
+		{"The Dinghy", true, sync.Mutex{}},
+		{"Leela's Cruiser", true, sync.Mutex{}},
+	}
+
+	requestsReceived = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "planet_express_ship_requests_received_total",
+			Help: "The total number of requests received by the ship service",
+		},
+		[]string{"method"},
+	)
+
+	requestsProcessed = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "planet_express_ship_requests_processed_total",
+			Help: "The total number of requests handled (processed) by the ship service",
+		},
+		[]string{"method", "code"},
+	)
+)
 
 func getStatus(w http.ResponseWriter, r *http.Request) {
+	requestsReceived.WithLabelValues(r.Method).Inc()
 	slog.Info("Received request for ship status")
 	if r.Method != http.MethodGet {
+		requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusMethodNotAllowed)).Inc()
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 	ship := r.URL.Query().Get("ship")
 	if ship == "" {
+		requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusBadRequest)).Inc()
 		http.Error(w, "Missing ship name in status request", http.StatusBadRequest)
 		return
 	}
@@ -48,15 +73,18 @@ func getStatus(w http.ResponseWriter, r *http.Request) {
 
 			fleet[i].Lock.Unlock()
 			if found {
+				requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusOK)).Inc()
 				return
 			}
 		}
 	}
 
+	requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusNotFound)).Inc()
 	http.NotFound(w, r)
 }
 
 func reserveShip(w http.ResponseWriter, r *http.Request) {
+	requestsReceived.WithLabelValues(r.Method).Inc()
 	slog.Info("Received request to reserve ship")
 
 	found := false
@@ -72,20 +100,24 @@ func reserveShip(w http.ResponseWriter, r *http.Request) {
 
 			fleet[i].Lock.Unlock()
 			if found {
+				requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusOK)).Inc()
 				return
 			}
 		}
 	}
 
 	slog.Warn("No ship is available")
+	requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusServiceUnavailable)).Inc()
 	http.Error(w, "No ship available", http.StatusServiceUnavailable)
 }
 
 func returnShip(w http.ResponseWriter, r *http.Request) {
+	requestsReceived.WithLabelValues(r.Method).Inc()
 	slog.Info("Received request to return ship")
 
 	var ship ShipInfo
 	if err := json.NewDecoder(r.Body).Decode(&ship); err != nil {
+		requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusServiceUnavailable)).Inc()
 		http.Error(w, "Failed to unmarshal data into ship member", http.StatusServiceUnavailable)
 		return
 	}
@@ -97,11 +129,13 @@ func returnShip(w http.ResponseWriter, r *http.Request) {
 			fleet[i].Available = true
 			fleet[i].Lock.Unlock()
 			slog.Info("Ship returned and is now available", "name", fleet[i].Name)
+			requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusOK)).Inc()
 			w.WriteHeader(http.StatusOK)
 			return
 		}
 	}
 
+	requestsProcessed.WithLabelValues(r.Method, strconv.Itoa(http.StatusNotFound)).Inc()
 	http.NotFound(w, r)
 }
 
@@ -116,10 +150,27 @@ func main() {
 	}
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: level})))
 
-	http.HandleFunc("/ship/status", getStatus)
-	http.HandleFunc("/ship/reserve", reserveShip)
-	http.HandleFunc("/ship/return", returnShip)
-	if err := http.ListenAndServe(":8080", nil); err != nil {
+	prometheus.MustRegister(requestsReceived)
+	prometheus.MustRegister(requestsProcessed)
+
+	shipMux := http.NewServeMux()
+	shipMux.HandleFunc("/ship/status", getStatus)
+	shipMux.HandleFunc("/ship/reserve", reserveShip)
+	shipMux.HandleFunc("/ship/return", returnShip)
+
+	metricsMux := http.NewServeMux()
+	metricsMux.Handle("/metrics", promhttp.Handler())
+
+	go func() {
+		slog.Info("Prometheus metrics endpoint running", "addr", ":2112")
+		if err := http.ListenAndServe(":2112", metricsMux); err != nil {
+			slog.Error("metrics server error", "err", err)
+			os.Exit(1)
+		}
+	}()
+
+	slog.Info("ShipService running", "addr", ":8080")
+	if err := http.ListenAndServe(":8080", shipMux); err != nil {
 		slog.Error("server error", "err", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Summary

- Add `requests_received_total{method}` and `requests_processed_total{method, code}` counters to the **crew**, **ship**, and **package** services, matching the pattern already in place for api, delivery, and traffic
- Each service now serves a `/metrics` endpoint on port **2112** using a dedicated mux (same as api/delivery)
- Updated each `Deployment.yaml` to expose port 2112, add it to the Kubernetes Service, and add a **ServiceMonitor** resource for Prometheus scraping
- Added `app: <service>` labels to Service metadata on crew/ship/package (required for ServiceMonitor selector to match)

## Test plan

- [ ] `go build ./...` from `planet-express/` compiles cleanly
- [ ] Run a service locally (e.g. `go run ./crew/main.go`) and confirm `curl http://localhost:2112/metrics` returns `planet_express_crew_requests_received_total`
- [ ] Send a request to port 8080 and re-scrape — counter values should increment with correct `method` and `code` labels
- [ ] `kubectl apply --dry-run=client -f planet-express/crew/Deployment.yaml` validates cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)